### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,6 @@
 from mycroft import MycroftSkill, intent_file_handler
 from tesla_powerwall_controller import PowerwallController
-from fuzzywuzzy import process
+from rapidfuzz import process
 
 class TeslaPowerwallSkill(MycroftSkill):
     def __init__(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 tesla-powerwall-controller>=0.2
-fuzzywuzzy
+rapidfuzz


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2.
For this reason this Pullrequest replaces FuzzyWuzzy with  [rapidfuzz](https://github.com/maxbachmann/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed.
Rapidfuzz is:
- Mit licensed so it can be used with the license used by this project
- Is faster than FuzzyWuzzy